### PR TITLE
Fix typo in container env

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -41,7 +41,7 @@
 
     // "containerEnv": {
     //     "EARTHLY_ORG": "YOUR EARTHLY ORG NAME HERE",
-    //     "EARHTLY_SATELLITE": "YOUR EARTHLY SATELLITE NAME HERE"
+    //     "EARTHLY_SATELLITE": "YOUR EARTHLY SATELLITE NAME HERE"
     // },
 
 


### PR DESCRIPTION
Just noticed this while trying to set up Earthly in a devcontainer